### PR TITLE
Revert "tls for api"

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,18 +2,8 @@
 
 FROM nginx:latest
 
-RUN openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
-COPY mkcert /usr/local/bin
-
-WORKDIR /etc/nginx/ssl
-
-RUN mkcert --install
-RUN mkcert -ecdsa arad-api
-
-WORKDIR /
-
 COPY ./etc/nginx/conf.d/default.conf /etc/nginx/conf.d/
 
-EXPOSE 443
+EXPOSE 80
 STOPSIGNAL SIGQUIT
 CMD ["nginx", "-g", "daemon off;"]

--- a/api/etc/nginx/conf.d/default.conf
+++ b/api/etc/nginx/conf.d/default.conf
@@ -1,24 +1,6 @@
 server {
-    listen       443 ssl;
-    server_name  arad-api;
-
-    ssl_certificate     /etc/nginx/ssl/arad-api.pem;
-    ssl_certificate_key /etc/nginx/ssl/arad-api-key.pem;
-
-    ssl_protocols TLSv1.3;
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
-    ssl_ecdh_curve secp384r1;
-    ssl_dhparam /etc/ssl/certs/dhparam.pem;
-
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_tickets off;
-    ssl_stapling on;
-    ssl_stapling_verify on;
-
-    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains";
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
+    listen       80;
+    server_name  localhost;
 
     # redirect server error pages to the static page /50x.html
     #

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -51,7 +51,7 @@ services:
       administrator:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -k https://localhost/health > /dev/null"]
+      test: ["CMD-SHELL", "curl http://localhost/health > /dev/null"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,12 @@ services:
       administrator:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -k https://localhost/health > /dev/null"]
+      test: ["CMD-SHELL", "curl http://localhost/health > /dev/null"]
       interval: 5s
       timeout: 5s
       retries: 5
     ports:
-      - "443:443" # this is how the front end talks to the api. port 80 is taken atm.
+      - "81:80" # this is how the front end talks to the api. port 80 is taken atm.
 
   identity:
     build:

--- a/front-end/src/api/Api.ts
+++ b/front-end/src/api/Api.ts
@@ -31,8 +31,8 @@ const Api = () => {
         options.body = JSON.stringify(body);
       }
 
-      const url = `https://${
-        currentHostname === "localhost" ? "localhost" : "api"
+      const url = `http://${
+        currentHostname === "localhost" ? "localhost:81" : "api"
       }/api/v1/${endpoint}`;
       const response = await fetch(url, options);
 


### PR DESCRIPTION
Reverts jasoncolburne/arad#139

I think we'll keep this simple for the time being, and in production see if we can rely on load balancers and service mesh to secure the transport