### PR TITLE
extract cypress artifacts locally

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -106,16 +106,12 @@ e2e() {
 }
 
 fast_e2e() {
-  local SERVICE=front-end-react
-  local COMMAND_STRING="yarn cypress:run"
-
-  set +e
-  read -r -d '' SHELL_SCRIPT << EOS
-${COMMAND_STRING}
-EOS
-  set -e
-
-  docker compose run --rm -v "$(pwd)/src/front-end/cypress/screenshots:/app/cypress/screenshots" -v "$(pwd)/src/front-end/cypress/videos:/app/cypress/videos" "${SERVICE}" bash -c "${SHELL_SCRIPT}"
+  docker compose run \
+      --rm \
+      -v "$(pwd)/src/front-end/cypress/screenshots:/app/cypress/screenshots" \
+      -v "$(pwd)/src/front-end/cypress/videos:/app/cypress/videos" \
+      front-end-react \
+      bash -c "yarn cypress:run"
 }
 
 back_end() {

--- a/scripts/test
+++ b/scripts/test
@@ -106,8 +106,16 @@ e2e() {
 }
 
 fast_e2e() {
-  unset ACTIVATE_SCRIPT
-  simple_compose_command front-end-react "yarn cypress:run"
+  local SERVICE=front-end-react
+  local COMMAND_STRING="yarn cypress:run"
+
+  set +e
+  read -r -d '' SHELL_SCRIPT << EOS
+${COMMAND_STRING}
+EOS
+  set -e
+
+  docker compose run --rm -v "$(pwd)/src/front-end/cypress/screenshots:/app/cypress/screenshots" -v "$(pwd)/src/front-end/cypress/videos:/app/cypress/videos" "${SERVICE}" bash -c "${SHELL_SCRIPT}"
 }
 
 back_end() {


### PR DESCRIPTION
## Rationale

The end-to-end runs didn't have mounts set up to export their artifacts.

## Changes

Adds bind mounts for Cypress `videos` and `screenshots`.

## Testing

```
scripts/test e2e
```