### PR TITLE
aggressive healthchecking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ x-common-environment: &common-environment
 
 x-healthcheck: &healthcheck
   test: ["CMD-SHELL", "curl http://localhost/health > /dev/null"]
-  interval: 5s
-  timeout: 5s
-  retries: 5
+  interval: 1s
+  timeout: 1s
+  retries: 25
 
 x-database-dependency: &database-dependency
   database:
@@ -37,9 +37,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost > /dev/null"]
-      interval: 10s
-      timeout: 10s
-      retries: 11
+      interval: 1s
+      timeout: 1s
+      retries: 110
     ports:
       - "80:80"
 
@@ -58,9 +58,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost/health > /dev/null"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      interval: 1s
+      timeout: 1s
+      retries: 25
     ports:
       - "8080:80" # this is how the front end talks to the api
 
@@ -136,9 +136,9 @@ services:
       - 'cache:/bitnami/redis/data'
     healthcheck:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      interval: 1s
+      timeout: 1s
+      retries: 25
 
   database:
     image: "postgres:14-bullseye"
@@ -149,9 +149,9 @@ services:
       - 'database:/var/lib/postgresql/data'
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      interval: 1s
+      timeout: 1s
+      retries: 25
 
 volumes:
   cache:

--- a/scripts/test
+++ b/scripts/test
@@ -91,13 +91,13 @@ e2e() {
   ./scripts/local down
   ./scripts/local daemonize
 
-  COUNT=24  # 12x5 minute periods = 2 minutes
+  COUNT=120
   for COUNTER in $(seq ${COUNT}); do
     if [[ $(docker inspect "$(docker ps | rg arad-front-end-react-1 | cut -d' ' -f1)" --format '{{ .State.Health.Status }}') == "healthy" ]]; then
       break
     else
       echo "waiting for front-end to spin up..."
-      sleep 5
+      sleep 1
     fi
   done
 


### PR DESCRIPTION
## Rationale

Faster startup, testing, etc. We have no reason to not do this locally.

## Changes

Changes timeouts and intervals for healthchecks.

## Testing

```sh
scripts/test all
```